### PR TITLE
요금제 갱신: 라이트 ₩6,900 / 프로 ₩19,800

### DIFF
--- a/src/app/price/page.js
+++ b/src/app/price/page.js
@@ -25,12 +25,12 @@ const PLANS = [
   {
     name: "라이트",
     description: "개인 크리에이터를 위한 플랜",
-    price: "₩3,900",
+    price: "₩6,900",
     priceSuffix: "/ 월",
     cta: "라이트 시작하기",
     highlight: true,
     badge: "추천",
-    quotas: ["기획안 10개까지 생성", "유튜브 링크 분석 5회 / 월"],
+    quotas: ["기획안 10개까지 생성", "유튜브 링크 분석 10회 / 월"],
     features: [
       { label: "1080p 화질", included: true },
       { label: "최대 영상 길이 10분", included: true },
@@ -41,11 +41,11 @@ const PLANS = [
   {
     name: "프로",
     description: "본격적인 운영을 위한 플랜",
-    price: "₩9,900",
+    price: "₩19,800",
     priceSuffix: "/ 월",
     cta: "프로 시작하기",
     highlight: false,
-    quotas: ["기획안 무제한 생성", "유튜브 링크 분석 20회 / 월"],
+    quotas: ["기획안 무제한 생성", "유튜브 링크 분석 30회 / 월"],
     features: [
       { label: "1080p 화질", included: true },
       { label: "최대 영상 길이 10분", included: true },


### PR DESCRIPTION
가격페이지(`/price`) 요금제 갱신.

- 라이트: ₩3,900 → **₩6,900**, 유튜브 분석 5회 → **10회/월**
- 프로: ₩9,900 → **₩19,800**, 유튜브 분석 20회 → **30회/월**
- 무료: 변경 없음 (기획안 3개 제한 유지)

가격 표시만 변경. 백엔드 과금/쿼터 enforcement는 별도 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)