### PR TITLE
fix(footer): 주소 309호 정정 + 연락처 추가

### DIFF
--- a/src/app/_components/footer.js
+++ b/src/app/_components/footer.js
@@ -23,7 +23,7 @@ export default function Footer() {
         조지컴퍼니 | 대표 조영진 | 사업자등록번호 108-39-69341
         <br className="sm:hidden" />
         <span className="hidden sm:inline"> | </span>
-        경기도 안양시 동안구 시민대로 327번길 11-41 3F 3900호 | contact@jojicompany.com
+        경기도 안양시 동안구 시민대로 327번길 11-41 3F 309호 | 연락처 010-7510-7298 | contact@jojicompany.com
       </p>
 
       <p className="mt-3 text-xs text-gray-600">

--- a/src/app/privacy/page.js
+++ b/src/app/privacy/page.js
@@ -110,7 +110,8 @@ export default function PrivacyPage() {
         <p>본 개인정보처리방침은 2026년 6월 8일부터 시행됩니다.</p>
         <p className="text-xs">
           상호: 조지컴퍼니 | 대표자: 조영진 | 사업자등록번호: 108-39-69341 | 주소: 경기도
-          안양시 동안구 시민대로 327번길 11-41 3F 3900호 | 문의: contact@jojicompany.com
+          안양시 동안구 시민대로 327번길 11-41 3F 309호 | 연락처: 010-7510-7298 | 문의:
+          contact@jojicompany.com
         </p>
       </Article>
     </div>

--- a/src/app/terms/page.js
+++ b/src/app/terms/page.js
@@ -210,7 +210,8 @@ export default function TermsPage() {
         <p>본 약관은 2026년 6월 8일부터 시행됩니다.</p>
         <p className="text-xs">
           상호: 조지컴퍼니 | 대표자: 조영진 | 사업자등록번호: 108-39-69341 | 주소: 경기도
-          안양시 동안구 시민대로 327번길 11-41 3F 3900호 | 문의: contact@jojicompany.com
+          안양시 동안구 시민대로 327번길 11-41 3F 309호 | 연락처: 010-7510-7298 | 문의:
+          contact@jojicompany.com
         </p>
       </Article>
     </div>


### PR DESCRIPTION
푸터/개인정보/약관 주소 3900호→309호, 연락처 010-7510-7298 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)