### PR TITLE
[codex] Migrate landing domain to easilystoryboard

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,12 @@
 /** @type {import('next').NextConfig} */
+const NEW_SITE_URL = "https://easilystoryboard.com";
+const OLD_SITE_HOSTS = ["easily.jojicompany.com", "www.easily.jojicompany.com"];
+const isProduction = process.env.NODE_ENV === "production";
+
 const nextConfig = {
+  assetPrefix: isProduction
+    ? process.env.NEXT_PUBLIC_ASSET_PREFIX || "https://easily.jojicompany.com"
+    : undefined,
   images: {
     remotePatterns: [
       {
@@ -18,6 +25,19 @@ const nextConfig = {
     } else {
       return [];
     }
+  },
+  redirects: async () => {
+    return OLD_SITE_HOSTS.map((host) => ({
+      source: "/:path*",
+      has: [
+        {
+          type: "host",
+          value: host,
+        },
+      ],
+      destination: `${NEW_SITE_URL}/:path*`,
+      permanent: true,
+    }));
   },
 };
 

--- a/src/app/_components/easilyPosts.js
+++ b/src/app/_components/easilyPosts.js
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Skeleton } from "@/app/_components/ui/skeleton";
 import { TypographyH2 } from "@/app/_components/ui/typography";
+import { API_BASE_URL } from "@/app/_consts/external_urls";
 
 /**
  * @typedef {Object} Post
@@ -23,7 +24,7 @@ export default function EasilyPosts() {
     const fetchPosts = async () => {
       try {
         const response = await fetch(
-          `${process.env.NEXT_PUBLIC_BASE_URL}/posts?categories=NOTICE`
+          `${API_BASE_URL}/posts?categories=NOTICE`
         );
         if (!response.ok)
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/app/_components/hooks/useAuth.js
+++ b/src/app/_components/hooks/useAuth.js
@@ -1,4 +1,8 @@
 import { useState, useEffect } from "react";
+import {
+  API_BASE_URL,
+  DASHBOARD_LOGIN_URL,
+} from "../../_consts/external_urls";
 
 const useAuth = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 여부
@@ -6,7 +10,7 @@ const useAuth = () => {
   const [userName, setUserName] = useState(""); // 사용자 이름
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/auth/profile`, {
+    fetch(`${API_BASE_URL}/auth/profile`, {
       method: "GET",
       credentials: "include",
     })
@@ -34,13 +38,11 @@ const useAuth = () => {
   }, []);
 
   const redirectToLogin = () => {
-    window.location.href =
-      "https://easily-dashboard.jojicompany.com/login?fallback=" +
-      window.location.href;
+    window.location.href = `${DASHBOARD_LOGIN_URL}?fallback=${window.location.href}`;
   };
 
   const handleLogout = () => {
-    fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/auth/logout`, {
+    fetch(`${API_BASE_URL}/auth/logout`, {
       method: "POST",
       credentials: "include",
     }).then((response) => {

--- a/src/app/_components/navBar/authDropdown.js
+++ b/src/app/_components/navBar/authDropdown.js
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
+import { DASHBOARD_URL } from "../../_consts/external_urls";
 
 export function AuthDropdown({
   isLoggedIn,
@@ -29,9 +30,7 @@ export function AuthDropdown({
             </DropdownMenuTrigger>
             <DropdownMenuContent className="rounded-b-xl border-none shadow-md bg-slate-50">
               <DropdownMenuItem asChild>
-                <Link
-                  href={`${process.env.NEXT_PUBLIC_DASHBOARD_BASE_URL}/dashboard/my`}
-                >
+                <Link href={`${DASHBOARD_URL}/dashboard/my`}>
                   내 정보
                 </Link>
               </DropdownMenuItem>

--- a/src/app/_components/navBar/desktopNavBar.js
+++ b/src/app/_components/navBar/desktopNavBar.js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useActiveSectionContext } from "../contexts/activeSectionContext";
 import { Button } from "../ui/button";
+import { DASHBOARD_URL } from "../../_consts/external_urls";
 import { NAV_BAR_MENU_ITEMS } from "../../_consts/nav_bar_menu_items";
 import { AuthDropdown } from "./authDropdown";
 
@@ -125,7 +126,7 @@ const DesktopNavbar = ({
         </div>
 
         <div className="flex items-center gap-4 z-10">
-          <Link href="https://easily-dashboard.jojicompany.com">
+          <Link href={DASHBOARD_URL}>
             <Button variant="link">대시보드</Button>
           </Link>
 

--- a/src/app/_components/navBar/mobileNavBar.js
+++ b/src/app/_components/navBar/mobileNavBar.js
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { X, TableOfContents, ChevronDown, ChevronUp } from "lucide-react";
 import { NAVBAR_HEIGHT } from "./desktopNavBar";
 import { Button } from "../ui/button";
+import { DASHBOARD_URL } from "../../_consts/external_urls";
 import { useActiveSectionContext } from "../contexts/activeSectionContext";
 import { useWindowScrollDirection } from "../hooks/useScrollDirection";
 import { NAV_BAR_MENU_ITEMS } from "../../_consts/nav_bar_menu_items";
@@ -133,7 +134,7 @@ export default function MobileNavbar({
             </div>
 
             <Button asChild>
-              <Link href="https://easily-dashboard.jojicompany.com">
+              <Link href={DASHBOARD_URL}>
                 대시보드
               </Link>
             </Button>

--- a/src/app/_components/sections/heroSection.js
+++ b/src/app/_components/sections/heroSection.js
@@ -7,6 +7,7 @@ import { useMediaQuery } from "react-responsive";
 import { CheckIcon, ChevronsDownIcon, LayoutDashboardIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { HeroLogo } from "../common/heroLogo";
+import { DASHBOARD_PROPOSAL_CREATE_URL } from "../../_consts/external_urls";
 // import logoSrc from '../../../../public/l'
 
 export function HeroSection({ ...props }) {
@@ -41,7 +42,7 @@ export function HeroSection({ ...props }) {
             </p>
           </div>
           <div className="flex flex-col md:flex-row md:justify-center w-full md:w-4/5 gap-4 mt-6">
-            <CTALink href="https://easily-dashboard.jojicompany.com/dashboard/proposal/create">
+            <CTALink href={DASHBOARD_PROPOSAL_CREATE_URL}>
               <LayoutDashboardIcon size={32} />
               지금 영상 뜯어보기
             </CTALink>

--- a/src/app/_components/sections/subscribeSection.js
+++ b/src/app/_components/sections/subscribeSection.js
@@ -5,6 +5,7 @@ import { Input } from "@/app/_components/ui/input";
 import { Button } from "@/app/_components/ui/button";
 import { useToast } from "@/app/_components/hooks/use-toast";
 import { SectionLayout } from "../layouts/sectionLayout";
+import { API_BASE_URL } from "../../_consts/external_urls";
 
 export function SubscribeSection({ ...props }) {
   const [email, setEmail] = useState("");
@@ -37,7 +38,7 @@ export function SubscribeSection({ ...props }) {
 
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/email-subscription/subscribe`,
+        `${API_BASE_URL}/email-subscription/subscribe`,
         {
           method: "POST",
           headers: {

--- a/src/app/_consts/external_urls.js
+++ b/src/app/_consts/external_urls.js
@@ -1,0 +1,17 @@
+const isDevelopment = process.env.NODE_ENV === "development";
+
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_EASILY_BASE_URL ||
+  (isDevelopment ? "http://localhost:3000" : "https://easilystoryboard.com")
+).replace(/\/$/, "");
+
+export const API_BASE_URL = (
+  process.env.NEXT_PUBLIC_BASE_URL || `${SITE_URL}/api`
+).replace(/\/$/, "");
+
+export const DASHBOARD_URL =
+  process.env.NEXT_PUBLIC_DASHBOARD_URL ||
+  (isDevelopment ? "http://localhost:3001" : SITE_URL);
+
+export const DASHBOARD_LOGIN_URL = `${DASHBOARD_URL}/login`;
+export const DASHBOARD_PROPOSAL_CREATE_URL = `${DASHBOARD_URL}/dashboard/proposal/create`;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -8,6 +8,9 @@ import { ActiveSectionProvider } from "./_components/contexts/activeSectionConte
 import "./globals.css";
 
 const fonts = Noto_Sans_KR({ subsets: ["latin"] });
+const siteUrl = (
+  process.env.NEXT_PUBLIC_EASILY_BASE_URL || "https://easilystoryboard.com"
+).replace(/\/$/, "");
 
 /**
  * @type {import('next').Viewport}
@@ -24,9 +27,7 @@ export const viewport = {
  * @type {import('next').Metadata}
  */
 export const metadata = {
-  metadataBase: process.env.NEXT_PUBLIC_EASILY_BASE_URL
-    ? new URL(process.env.NEXT_PUBLIC_EASILY_BASE_URL)
-    : undefined,
+  metadataBase: new URL(siteUrl),
   title: "이즐리 - 영상 기획을 더 쉽게, 더 강력하게",
   description:
     "이즐리는 영상 기획을 위한 전문 도구로, 자유로운 블록 편집을 지원합니다. 효율적인 기획을 돕고 팀 협업을 강화하세요.",
@@ -40,7 +41,7 @@ export const metadata = {
     title: "이즐리 - 영상 기획을 더 쉽게, 더 강력하게",
     description:
       "이즐리는 영상 기획을 위한 전문 도구로, 자유로운 블록 편집을 지원합니다. 효율적인 기획을 돕고 팀 협업을 강화하세요.",
-    url: "https://easily.jojicompany.com",
+    url: siteUrl,
     siteName: "이즐리",
     locale: "ko_KR",
     type: "website",
@@ -73,9 +74,9 @@ export const metadata = {
   },
 
   alternates: {
-    canonical: "https://easily.jojicompany.com",
+    canonical: siteUrl,
     languages: {
-      "ko-KR": "https://easily.jojicompany.com",
+      "ko-KR": siteUrl,
     },
   },
 };

--- a/src/app/post/[id]/page.js
+++ b/src/app/post/[id]/page.js
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { formatDate } from "@/app/_utils/formatDate";
 import { Separator } from "@/app/_components/ui/separator";
 import { Button } from "@/app/_components/ui/button";
+import { API_BASE_URL } from "@/app/_consts/external_urls";
 
 export default function CommunityPostDetailPage({ params }) {
   const { id } = use(params);
@@ -15,7 +16,7 @@ export default function CommunityPostDetailPage({ params }) {
   useEffect(() => {
     const fetchPostDetail = async () => {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/posts/${id}`
+        `${API_BASE_URL}/posts/${id}`
       );
       const data = await response.json();
       setPostData(data);

--- a/src/app/post/page.js
+++ b/src/app/post/page.js
@@ -21,6 +21,7 @@ import { Detector } from "../_components/common/detector";
 import { useActiveSectionContext } from "../_components/contexts/activeSectionContext";
 import { Separator } from "../_components/ui/separator";
 import dayjs from "dayjs";
+import { API_BASE_URL } from "../_consts/external_urls";
 
 const FETCH_POSTS_LIMIT = 10;
 
@@ -54,7 +55,7 @@ export default function NoticePage() {
   const fetchPosts = async (page) => {
     setLoading(true);
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_BASE_URL}/posts?page=${page}&limit=${FETCH_POSTS_LIMIT}&categories=NOTICE`
+      `${API_BASE_URL}/posts?page=${page}&limit=${FETCH_POSTS_LIMIT}&categories=NOTICE`
     );
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/app/price/page.js
+++ b/src/app/price/page.js
@@ -1,15 +1,12 @@
 import { Check, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { DASHBOARD_URL } from "../_consts/external_urls";
 
 // ──────────────────────────────────────────────────────────
 // 요금제 정책 (레이아웃은 참고 디자인, 색은 easily 주황 브랜드)
 // 모든 플랜 공통: 최대 영상 길이 5분
 // ──────────────────────────────────────────────────────────
 // 대시보드(결제 페이지) 베이스 URL — 클릭 시 결제로 이동
-const DASHBOARD_URL =
-  process.env.NEXT_PUBLIC_DASHBOARD_URL ||
-  "https://easily-dashboard.jojicompany.com";
-
 const PLANS = [
   {
     name: "무료",

--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,9 +1,13 @@
 export default function robots() {
+  const baseUrl = (
+    process.env.NEXT_PUBLIC_EASILY_BASE_URL || "https://easilystoryboard.com"
+  ).replace(/\/$/, "");
+
   return {
     rules: {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://easily.jojicompany.com/sitemap.xml",
+    sitemap: `${baseUrl}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -1,4 +1,6 @@
-const baseUrl = process.env.NEXT_PUBLIC_EASILY_BASE_URL;
+const baseUrl = (
+  process.env.NEXT_PUBLIC_EASILY_BASE_URL || "https://easilystoryboard.com"
+).replace(/\/$/, "");
 export default async function sitemap() {
   return [
     {


### PR DESCRIPTION
## Summary
- Point landing metadata, sitemap, robots, dashboard links, and API calls at `https://easilystoryboard.com`.
- Add redirects from the old landing hosts to the new domain.
- Keep production static assets loading from the existing landing host to avoid `/_next` path collisions in the single-domain CloudFront router.

## Validation
- `npm run build`
