### PR TITLE
[codex] Preserve landing static assets during old-domain redirects

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,7 +28,7 @@ const nextConfig = {
   },
   redirects: async () => {
     return OLD_SITE_HOSTS.map((host) => ({
-      source: "/:path*",
+      source: "/:path((?!_next/).*)",
       has: [
         {
           type: "host",


### PR DESCRIPTION
## Summary
- exclude /_next assets from old-host redirects so the production asset prefix can keep serving static files from the existing landing host

## Test
- npm run build