### PR TITLE
[codex] Skip old-domain redirects for routed origin requests

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -35,6 +35,13 @@ const nextConfig = {
           value: host,
         },
       ],
+      missing: [
+        {
+          type: "header",
+          key: "x-easily-origin-router",
+          value: "1",
+        },
+      ],
       destination: `${NEW_SITE_URL}/:path*`,
       permanent: true,
     }));


### PR DESCRIPTION
## Summary
- keep old-host redirects for direct old-domain visits
- skip those redirects when the easilystoryboard CloudFront router calls this app as an origin

## Test
- npm run build