### PR TITLE
[codex] Remove landing old-host redirects for routed origin

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const NEW_SITE_URL = "https://easilystoryboard.com";
-const OLD_SITE_HOSTS = ["easily.jojicompany.com", "www.easily.jojicompany.com"];
 const isProduction = process.env.NODE_ENV === "production";
 
 const nextConfig = {
@@ -25,26 +23,6 @@ const nextConfig = {
     } else {
       return [];
     }
-  },
-  redirects: async () => {
-    return OLD_SITE_HOSTS.map((host) => ({
-      source: "/:path((?!_next/).*)",
-      has: [
-        {
-          type: "host",
-          value: host,
-        },
-      ],
-      missing: [
-        {
-          type: "header",
-          key: "x-easily-origin-router",
-          value: "1",
-        },
-      ],
-      destination: `${NEW_SITE_URL}/:path*`,
-      permanent: true,
-    }));
   },
 };
 


### PR DESCRIPTION
## Summary
- remove landing app old-host redirects because the easilystoryboard CloudFront router uses the current landing host as its origin
- prevents self-redirect loops on https://easilystoryboard.com

## Test
- npm run build