### PR TITLE
[codex] Restore landing old-host redirects

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const NEW_SITE_URL = "https://easilystoryboard.com";
+const OLD_SITE_HOSTS = ["easily.jojicompany.com", "www.easily.jojicompany.com"];
 const isProduction = process.env.NODE_ENV === "production";
 
 const nextConfig = {
@@ -23,6 +25,26 @@ const nextConfig = {
     } else {
       return [];
     }
+  },
+  redirects: async () => {
+    return OLD_SITE_HOSTS.map((host) => ({
+      source: "/:path((?!_next/).*)",
+      has: [
+        {
+          type: "host",
+          value: host,
+        },
+      ],
+      missing: [
+        {
+          type: "header",
+          key: "x-easily-origin-router",
+          value: "1",
+        },
+      ],
+      destination: `${NEW_SITE_URL}/:path*`,
+      permanent: true,
+    }));
   },
 };
 


### PR DESCRIPTION
## Summary
- revert the removal of landing old-host redirects
- keeps direct easily.jojicompany.com visits redirecting to easilystoryboard.com while the CloudFront router uses the internal origin header path

## Test
- npm run build