### PR TITLE
fix(landing): normalize legacy public urls

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,19 @@
 /** @type {import('next').NextConfig} */
 const NEW_SITE_URL = "https://easilystoryboard.com";
 const OLD_SITE_HOSTS = ["easily.jojicompany.com", "www.easily.jojicompany.com"];
+const OLD_SITE_URLS = [
+  ...OLD_SITE_HOSTS.map((host) => `https://${host}`),
+  "https://easily-dashboard.jojicompany.com",
+];
+const normalizePublicUrl = (url) => {
+  const normalized = (url || NEW_SITE_URL).replace(/\/$/, "");
+  return OLD_SITE_URLS.includes(normalized) ? NEW_SITE_URL : normalized;
+};
 const isProduction = process.env.NODE_ENV === "production";
 
 const nextConfig = {
   assetPrefix: isProduction
-    ? process.env.NEXT_PUBLIC_ASSET_PREFIX || "https://easily.jojicompany.com"
+    ? normalizePublicUrl(process.env.NEXT_PUBLIC_ASSET_PREFIX)
     : undefined,
   images: {
     remotePatterns: [

--- a/src/app/_consts/external_urls.js
+++ b/src/app/_consts/external_urls.js
@@ -1,17 +1,20 @@
+import { NEW_SITE_URL, normalizePublicUrl } from "./public_urls";
+
 const isDevelopment = process.env.NODE_ENV === "development";
 
-export const SITE_URL = (
+export const SITE_URL = normalizePublicUrl(
   process.env.NEXT_PUBLIC_EASILY_BASE_URL ||
-  (isDevelopment ? "http://localhost:3000" : "https://easilystoryboard.com")
-).replace(/\/$/, "");
+    (isDevelopment ? "http://localhost:3000" : NEW_SITE_URL)
+);
 
 export const API_BASE_URL = (
   process.env.NEXT_PUBLIC_BASE_URL || `${SITE_URL}/api`
 ).replace(/\/$/, "");
 
-export const DASHBOARD_URL =
+export const DASHBOARD_URL = normalizePublicUrl(
   process.env.NEXT_PUBLIC_DASHBOARD_URL ||
-  (isDevelopment ? "http://localhost:3001" : SITE_URL);
+    (isDevelopment ? "http://localhost:3001" : SITE_URL)
+);
 
 export const DASHBOARD_LOGIN_URL = `${DASHBOARD_URL}/login`;
 export const DASHBOARD_PROPOSAL_CREATE_URL = `${DASHBOARD_URL}/dashboard/proposal/create`;

--- a/src/app/_consts/public_urls.js
+++ b/src/app/_consts/public_urls.js
@@ -1,0 +1,12 @@
+export const NEW_SITE_URL = "https://easilystoryboard.com";
+
+const OLD_SITE_URLS = new Set([
+  "https://easily.jojicompany.com",
+  "https://www.easily.jojicompany.com",
+  "https://easily-dashboard.jojicompany.com",
+]);
+
+export const normalizePublicUrl = (url, fallback = NEW_SITE_URL) => {
+  const normalized = (url || fallback).replace(/\/$/, "");
+  return OLD_SITE_URLS.has(normalized) ? NEW_SITE_URL : normalized;
+};

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -5,12 +5,11 @@ import NavBar from "./_components/navBar/navBar";
 import Footer from "./_components/footer";
 import { Toaster } from "./_components/ui/toaster";
 import { ActiveSectionProvider } from "./_components/contexts/activeSectionContext";
+import { normalizePublicUrl } from "./_consts/public_urls";
 import "./globals.css";
 
 const fonts = Noto_Sans_KR({ subsets: ["latin"] });
-const siteUrl = (
-  process.env.NEXT_PUBLIC_EASILY_BASE_URL || "https://easilystoryboard.com"
-).replace(/\/$/, "");
+const siteUrl = normalizePublicUrl(process.env.NEXT_PUBLIC_EASILY_BASE_URL);
 const seoTitle =
   "이즐리 - 광고·영화 레퍼런스 분석 | 국내 1위 온라인 스토리보드";
 const seoDescription =

--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,7 +1,7 @@
+import { normalizePublicUrl } from "./_consts/public_urls";
+
 export default function robots() {
-  const baseUrl = (
-    process.env.NEXT_PUBLIC_EASILY_BASE_URL || "https://easilystoryboard.com"
-  ).replace(/\/$/, "");
+  const baseUrl = normalizePublicUrl(process.env.NEXT_PUBLIC_EASILY_BASE_URL);
 
   return {
     rules: {

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -1,6 +1,6 @@
-const baseUrl = (
-  process.env.NEXT_PUBLIC_EASILY_BASE_URL || "https://easilystoryboard.com"
-).replace(/\/$/, "");
+import { normalizePublicUrl } from "./_consts/public_urls";
+
+const baseUrl = normalizePublicUrl(process.env.NEXT_PUBLIC_EASILY_BASE_URL);
 export default async function sitemap() {
   return [
     {


### PR DESCRIPTION
## Summary
- normalize legacy public URL env values to https://easilystoryboard.com
- protect landing asset prefix, metadata, robots, sitemap, and dashboard links from stale env values

## Test
- NEXT_PUBLIC_ASSET_PREFIX=https://easily.jojicompany.com NEXT_PUBLIC_EASILY_BASE_URL=https://easily.jojicompany.com NEXT_PUBLIC_LANDING_URL=https://easily.jojicompany.com NEXT_PUBLIC_DASHBOARD_URL=https://easily-dashboard.jojicompany.com npm run build