### PR TITLE
[codex] Add Channel Talk widget to landing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "easily-linding-page",
       "version": "0.1.0",
       "dependencies": {
+        "@channel.io/channel-web-sdk-loader": "^2.0.2",
         "@jojicompany-dev/easily-post-editor": "^0.1.1",
         "@next/third-parties": "^15.1.7",
         "@radix-ui/react-accordion": "^1.2.2",
@@ -74,6 +75,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@channel.io/channel-web-sdk-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@channel.io/channel-web-sdk-loader/-/channel-web-sdk-loader-2.0.2.tgz",
+      "integrity": "sha512-43xRJX+BUjb5vRw5A/LDkgE9syJYTPERf7xo49Fz5MMpA9UtzPWHWyzN2QU1/tTT2uu5tpxapT2BgMx6FfP2qg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@channel.io/channel-web-sdk-loader": "^2.0.2",
     "@jojicompany-dev/easily-post-editor": "^0.1.1",
     "@next/third-parties": "^15.1.7",
     "@radix-ui/react-accordion": "^1.2.2",

--- a/src/app/_components/channelTalkClient.js
+++ b/src/app/_components/channelTalkClient.js
@@ -1,0 +1,26 @@
+"use client";
+
+import * as ChannelService from "@channel.io/channel-web-sdk-loader";
+import { useEffect } from "react";
+
+const CHANNEL_TALK_PLUGIN_KEY =
+  process.env.NEXT_PUBLIC_CHANNEL_TALK_PLUGIN_KEY ||
+  "ffa758b3-c304-433a-9f6f-fd5925945e0f";
+
+export default function ChannelTalkClient() {
+  useEffect(() => {
+    if (!CHANNEL_TALK_PLUGIN_KEY) return;
+
+    ChannelService.loadScript();
+    ChannelService.boot({
+      pluginKey: CHANNEL_TALK_PLUGIN_KEY,
+      language: "ko",
+    });
+
+    return () => {
+      ChannelService.shutdown();
+    };
+  }, []);
+
+  return null;
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -5,6 +5,7 @@ import NavBar from "./_components/navBar/navBar";
 import Footer from "./_components/footer";
 import { Toaster } from "./_components/ui/toaster";
 import { ActiveSectionProvider } from "./_components/contexts/activeSectionContext";
+import ChannelTalkClient from "./_components/channelTalkClient";
 import { normalizePublicUrl } from "./_consts/public_urls";
 import "./globals.css";
 
@@ -131,6 +132,7 @@ export default function RootLayout({ children }) {
           <NavBar />
           {children}
           <Toaster />
+          <ChannelTalkClient />
           <Footer />
         </ActiveSectionProvider>
         <script


### PR DESCRIPTION
## Summary
- add the official Channel Talk web SDK loader
- boot Channel Talk from the landing root layout for anonymous visitors

## Validation
- `npm run build`